### PR TITLE
Path absoluto en favicon para que funcione en pages

### DIFF
--- a/pycltheme/templates/headermeta.html
+++ b/pycltheme/templates/headermeta.html
@@ -10,7 +10,7 @@
         <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/bootstrap.min.css" />
         <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/cl.css" />
         <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/pygment.css" />
-        <link rel="shortcut icon" type="image/png" href="images/favicon.png"/>
+        <link rel="shortcut icon" type="image/png" href="{{ SITEURL }}/images/favicon.png"/>
         <script src="https://kit.fontawesome.com/6cf87c29c5.js" crossorigin="anonymous"></script>
 
         <!-- Optional JavaScript -->


### PR DESCRIPTION
Usando ahora path absoluto para el favicon para que funcione correctamente en paginas que no están en la raiz (pages por ejemplo)