### PR TITLE
Inclusión de Pyladies Santiago y Cambio Python 101

### DIFF
--- a/content/pages/grupos.md
+++ b/content/pages/grupos.md
@@ -22,8 +22,9 @@ actualizar la lista!
 **Región Metropolitana**
 
 * [Meetup Analytics & Python](https://www.meetup.com/es-ES/Analytics-y-Python)
-* [Meetup Python 101](https://www.meetup.com/python101/)
+* [Meetup Python Chile (oficial)](https://www.meetup.com/es/pythonchiledev/)
 * [Meetup Python Chile](https://www.meetup.com/python-chile/)
+* [Meetup PyLadies Santiago](https://www.meetup.com/es/pyladies-santiago-de-chile/)
 * [Django Girls Santiago](https://www.facebook.com/djangogirlssantiago/)
 
 **Python Chile**


### PR DESCRIPTION
- Inclusión de Pyladies Santiago
- Cambio Python 101 por Python Chile (oficial)