### PR TITLE
Reducir tamaño entradas blog

### DIFF
--- a/pycltheme/static/css/cl.css
+++ b/pycltheme/static/css/cl.css
@@ -137,7 +137,7 @@
 /* Images from cards with the same height */
 .card-img-top {
   width: 100%;
-  height: 12vw;
+  height: 8vw;
   object-fit: cover;
   max-height: 30vh;
 }
@@ -161,6 +161,14 @@
 
 .card-footer {
   padding: 5px;
+}
+
+.card-title {
+  font-size: 0.9em;
+}
+
+.card-subtitle {
+  font-size: 0.9em;
 }
 
 .list-inline-item {

--- a/pycltheme/templates/card.html
+++ b/pycltheme/templates/card.html
@@ -1,5 +1,5 @@
 
-    <div class="col-md-6 col-lg-6 mb-5">
+    <div class="col-md-4 col-lg-4 mb-5">
       <div class="card h-100">
         <a href="{{ SITEURL }}/{{ article.url }}">
         <img class="card-img-top img-fluid"


### PR DESCRIPTION
Actualmente son 2 por fila, pero se ven bastante grandes. Esto las cambia a tres y reduce un poco la imagen para que se vea mejor