### PR TITLE
:construction: Se agrega link de formulario para registar voluntarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@
   ```
   pelican -l
   ```
-  Podras revisar el contenido generado en la url  http://127.0.0.1:8000
+  Podrás revisar el contenido generado en la url  http://127.0.0.1:8000
   y con la combinación de teclas `Ctrl + c` cierras el proceso.
 
 ## Despliegue
 
-* Se utiliazarán Github Actions, para hacer un despliegue al servidor.
+* Se utilizarán Github Actions, para hacer un despliegue al servidor.
 * De momento es una acción sencilla que obtiene la última versión, genera el
   sitio y lo copia al directory a donde apunta la URL.
 

--- a/content/pages/recursos.md
+++ b/content/pages/recursos.md
@@ -1,7 +1,11 @@
 Title: Recursos
-Date: 2022-03-23 10:00
+Date: 2024-12-21 21:00
 
+### ¿Cómo ser voluntario?
 
+Si quieres ser parte del maravilloso equipo de Python Chile sólo debe rellenar el siguiente formulario
+
+* [Formulario de inscripción](https://docs.google.com/forms/d/e/1FAIpQLSdhHlnqwmYffl6JNzbAZ4IRRyM_8fcOB1QH0hyz6Vwi3VFOwg/viewform?usp=sf_link)
 
 ### ¿Cómo organizar un PyDay?
 
@@ -9,12 +13,8 @@ En esta sección encontrarás las recomendaciones para organizar una PyDay basad
 
 * [Organiza un PyDay](/pages/como-organizar-un-pyday.html) 
 
-
 ### Python en Español
 
 En el sitio de Python en Español encontrarás recursos educativos desde principiante a avanzado: 
 
-* [Hablemos Python](https://hablemospython.dev) 
-
-
-
+* [Hablemos Python](https://hablemospython.dev)


### PR DESCRIPTION
El día viernes 20 de diciembre Rafael Mascayano informó algo que no me había fijado y es que en la página principal no se encuentra el link para rellenar el formulario y ser parte de Python Chile, razón por la cual se procede a agregar el link en el área de recursos.

close #106 