### PR TITLE
pch-feature-118-add-codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Se añade el equipo de revisión
+* @python-chile/codeowners


### PR DESCRIPTION
Se agrega el codeowners para que asigne automáticamente a los revisores de cualquier cambio