### PR TITLE
Agrega navegación para más posts

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -129,6 +129,7 @@ IMAGE_PROCESS = {
 }
 
 DEFAULT_PAGINATION = 6
+PAGINATED_DIRECT_TEMPLATES = ["index", "archives"]
 
 # Uncomment following line if you want document-relative URLs when developing
 # RELATIVE_URLS = True

--- a/pycltheme/templates/archives.html
+++ b/pycltheme/templates/archives.html
@@ -5,10 +5,13 @@
 {% block content %}
 <h1 class="pb-5">Entradas del Blog</h1>
 
-    <div class="row">
-      {% for article in dates%}
-        {% include 'card-page.html' %}
-      {% endfor %}
-    </div>
+<div class="row">
+  {% for article in articles_page.object_list %}
+  {% include 'card-page.html' %}
+  {% endfor %}
+</div>
+{% if articles_page.has_other_pages() %}
+{% include 'pagination.html' %}
+{% endif %}
 
 {% endblock %}

--- a/pycltheme/templates/index.html
+++ b/pycltheme/templates/index.html
@@ -4,22 +4,27 @@
 <section id="content">
 
   <!-- Entradas Blog -->
-<div class="pt-1 pb-1 blog-entries">
-  <div class="container">
-    {% block content_title %}
-    {% endblock %}
-    <div class="row flex-column-reverse flex-md-row">
-      <div class="col-4 col-12">
-        <h3 class="text-center pb-5 mb-3 titulo-bold">ÚLTIMAS ENTRADAS</h3>
-        <div class="row">
-          {% for article in dates[:6] %}
-           {% include 'card.html' %}
-          {% endfor %}
+  <div class="pt-1 pb-1 blog-entries">
+    <div class="container">
+      {% block content_title %}
+      {% endblock %}
+      <div class="row flex-column-reverse flex-md-row">
+        <div class="col-4 col-12">
+          <h3 class="text-center pb-5 mb-3 titulo-bold">ÚLTIMAS ENTRADAS</h3>
+          <div class="row">
+            {% for article in dates[:6] %}
+            {% include 'card.html' %}
+            {% endfor %}
+          </div>
+          {% if dates|length > 6 %}
+          <div class="row pt-1 pb-5 justify-content-center">
+            <a href="{{ SITEURL }}/archives2.html" class="btn btn-primary">Leer más articulos</a>
+          </div>
+          {% endif %}
         </div>
       </div>
     </div>
   </div>
-</div>
 
 </section><!-- /#content -->
 
@@ -37,7 +42,7 @@
           <p> ¿Te gustaría patrocinar las actividades de la comunidad Python Chile?</p>
           <p> Contáctanos y te contamos como: contacto@pythonchile.cl
         </div>
-<!--
+        <!--
         <div class="col-md-2 text-center">
             <a href="https://it-talenthh.com/" target="_blank">
               <img class="img-fluid" src="images/patrocinantes/logo_ittalent.png" alt="IT-Talent">

--- a/pycltheme/templates/pagination.html
+++ b/pycltheme/templates/pagination.html
@@ -3,13 +3,13 @@
 {% set last_page = articles_paginator.page(articles_paginator.num_pages) %}
 <p class="paginator">
     {% if articles_page.has_previous() %}
-        <a href="{{ SITEURL }}/{{ first_page.url }}">&#8647;</a>
-        <a href="{{ SITEURL }}/{{ articles_previous_page.url }}">&laquo;</a>
+    <a href="{{ SITEURL }}/{{ first_page.url }}">Inicio</a>
+    <a href="{{ SITEURL }}/{{ articles_previous_page.url }}">&laquo;</a>
     {% endif %}
     Página {{ articles_page.number }} / {{ articles_paginator.num_pages }}
     {% if articles_page.has_next() %}
-        <a href="{{ SITEURL }}/{{ articles_next_page.url }}">&raquo;</a>
-        <a href="{{ SITEURL }}/{{ last_page.url }}">&#8649;</a>
+    <a href="{{ SITEURL }}/{{ articles_next_page.url }}">&raquo;</a>
+    <a href="{{ SITEURL }}/{{ last_page.url }}">Final</a>
     {% endif %}
 </p>
 {% endif %}


### PR DESCRIPTION
e añade un botón para ver más posts en la página principal y paginación en la sección Archives.

Cambios

Botón “Ver más posts” en home.

Paginación en Archives.


El boton 
<img width="1004" height="578" alt="Screenshot 2026-01-16 at 14-21-31 Comunidad Chilena de Python" src="https://github.com/user-attachments/assets/dfc2036d-9af8-453d-89a5-2953d60ea4a6" />
Paginación 
<img width="1156" height="584" alt="Screenshot 2026-01-16 at 14-22-51 Comunidad Chilena de Python" src="https://github.com/user-attachments/assets/b077eb1a-546f-4d10-b9c8-61dc4f4b78fa" />
