### PR TITLE
feat: Agrega páginas de asociación y estatutos

### DIFF
--- a/content/pages/asociacion.md
+++ b/content/pages/asociacion.md
@@ -1,0 +1,40 @@
+Title: Asociación
+Date: 2026-07-04 10:00
+
+La **Asociación Python Software Chile** es la entidad legal que respalda a la
+comunidad de Python Chile, permitiendo formalizar sus actividades, gestionar
+recursos y representar a la comunidad ante otras organizaciones.
+
+## Directiva
+
+* **Presidente:** Sebastián Flores Benner
+* **Vicepresidente:** Cristina Verdugo Palma
+* **Secretario:** Aldo Caneo Abarca
+* **Tesorero:** Carlos Maldonado Rivera
+* **Director:** Alexis Alva Núñez
+
+## Estatutos
+
+Los estatutos de la asociación se encuentran disponibles en la página de
+[Estatutos]({filename}/pages/estatutos.md).
+
+## Incorporación de nuevos socios
+
+Se aceptará como socio a quien cumpla los siguientes criterios:
+
+* Haber sido coordinador de Python Chile al menos 12 meses.
+* Haber participado como organizador o liderando una actividad en un PyDay o
+  PyCon.
+* Haber llevado a cabo labores en al menos un equipo de trabajo, lo cual debe
+  ser validado por su jefe de comisión.
+
+La cuota de incorporación y la cuota anual están por definir.
+
+## Datos de facturación
+
+Si necesitas emitir una factura a la asociación, utiliza los siguientes datos:
+
+* **Razón social:** Asociación Python Software Chile
+* **RUT:** 65.215.141-8
+* **Giro:** Otras actividades de tecnología de la información
+* **Dirección:** Capitanía 80 Of. 108 PS1, Las Condes, Santiago

--- a/content/pages/estatutos.md
+++ b/content/pages/estatutos.md
@@ -1,0 +1,954 @@
+Title: Estatutos
+Date: 2026-07-04 10:00
+
+Estatutos de la **Asociación Python Software Chile**, aprobados en Asamblea
+General Extraordinaria de Socios celebrada el 30 de mayo de 2026, que reforman
+los estatutos originales de la constitución de la asociación, otorgados el 29
+de julio de 2022.
+
+Para más información sobre la asociación, visita la página de
+[Asociación]({filename}/pages/asociacion.md).
+
+## Título I: Del nombre, domicilio, objeto, duración
+
+**Artículo Primero:** Constitúyase una Asociación de Derecho Privado, sin fin
+de lucro, que se denominará "Asociación PYTHON SOFTWARE CHILE", pudiendo
+utilizar el nombre de fantasía "PYTHON CHILE".
+
+La Asociación se regirá por las normas del Título XXXIII del Libro Primero del
+Código Civil, por las disposiciones contenidas en la Ley N°20.500, sobre
+Asociaciones y Participación Ciudadana en la Gestión Pública, o por la
+disposición legal que la reemplace y por los presentes estatutos.
+
+**Artículo Segundo:** El domicilio de la Asociación será la Comuna de Las
+Condes, Región Metropolitana, sin perjuicio de poder desarrollar sus
+actividades en otros puntos del país.
+
+**Artículo Tercero:** La Asociación no persigue ni se propone fines sindicales
+o de lucro, ni aquellos de entidades que deban regirse por un estatuto legal
+propio. Estará prohibida toda acción de carácter político partidista.
+
+**Artículo Cuarto:** La Asociación tendrá por finalidad u objetivo promover el
+uso, la cultura y desarrollo del lenguaje de programación Python; servir como
+plataforma de difusión y para la cooperación entre los diversos agentes
+involucrados en el desarrollo de la sociedad y las tecnologías; promover y
+desarrollar actividades que vayan en apoyo del crecimiento de la comunidad de
+Python en Chile y otros países. Para ello, la Asociación se basa en:
+
+* a) integración, inclusión, diversidad, ideas, proyectos;
+* b) servir de plataforma institucional a iniciativas nacidas desde la
+  comunidad;
+* c) crear grupos y comisiones de trabajo para temas específicos;
+* d) servir de contacto formal con empresas y gobierno;
+* e) apoyar en la búsqueda de financiamiento de actividades y proyectos
+  comunitarios;
+* f) generar contenidos y recursos educativos abiertos;
+* g) divulgar temas de interés para la comunidad.
+
+Para conseguir su objetivo y sin que esta enumeración sea taxativa, sino
+meramente enunciativa, la Asociación podrá realizar las siguientes
+actividades:
+
+* a) Investigación, desarrollo e innovación tecnológica en los campos objeto
+  de la Asociación.
+* b) La realización de proyectos de investigación fundamental o industrial,
+  desarrollo e innovación tecnológica propios o en cooperación con empresas,
+  universidades y/o centros públicos de investigación u otras entidades, con
+  el objeto de generar y difundir conocimiento tecnológico y colaborar en la
+  transferencia de resultados de investigación entre los organismos públicos y
+  privados de investigación y las empresas.
+* c) La realización de proyectos de investigación, desarrollo e innovación
+  contratados, licitados o solicitados por empresas, el Estado, instituciones
+  educacionales secundarias, universitarias o técnicas, u otras entidades, que
+  permitan maximizar la aplicación del conocimiento generado por la
+  Asociación.
+* d) La atención a las necesidades tecnológicas de las instituciones
+  educacionales y privadas que lo requieran, prestando servicios de
+  asistencia técnica, como la formación técnica especializada, así como
+  difusión de información y otros servicios análogos vinculados a la gestión
+  del conocimiento, la tecnología y la innovación.
+* e) El fomento, difusión cultural y desarrollo de investigación cooperativa
+  entre distintos grupos de la sociedad, comunidades, estado, educación,
+  sector privado, pymes.
+* f) Fomento de emprendedores digitales y de empresas de "nueva economía".
+* g) Captación, diseño, gestión y ejecución de proyectos y programas de
+  investigación, desarrollo tecnológico e innovación relacionados con el
+  lenguaje python, u otros lenguajes de programación e inteligencia
+  artificial.
+* h) Asesoramiento y transferencia tecnológica a empresas e instituciones,
+  con especial interés en el ámbito de la administración informática.
+* i) Realización de investigaciones, difusión y estudios de diversa índole
+  relacionados con el desarrollo de la inteligencia artificial y lenguajes de
+  programación.
+* j) Fomento de redes de cooperación en el sector tecnológico nacional e
+  internacional.
+* k) Establecer canales de información, cooperación e intercambio con
+  entidades públicas, particulares e instituciones afines de todo el mundo,
+  que posibiliten la colaboración y la realización de proyectos comunes
+  tendentes a promover el desarrollo humano y la igualdad de oportunidades de
+  acceso en los ámbitos de la Asociación.
+* l) La elaboración, edición y publicación en papel o en soporte audiovisual
+  o multimedia de materiales vinculados con los fines de la Asociación.
+* m) Formación en materias relacionadas con los fines de la Asociación.
+* n) Acciones de impulso, promoción, formación y desarrollo en los ámbitos
+  institucionales, empresariales, sociales y educativos, para lo que diseñará
+  y ejecutará estrategias y proyectos en los ámbitos regional, nacional e
+  internacional.
+* o) Difusión cultural, organización y promoción de todo tipo de eventos y
+  actos como conferencias, coloquios, cursos o seminarios en materias
+  relacionadas con los fines de la Asociación.
+* p) Cualesquiera otras actividades no mencionadas expresamente pero que sean
+  adecuadas para el cumplimiento de sus fines.
+
+La Asociación podrá realizar actividades económicas que se relacionen con sus
+fines; asimismo, podrá invertir sus recursos de la manera que decidan sus
+órganos de administración.
+
+Las rentas que perciba de esas actividades sólo deberán destinarse a los fines
+de la Asociación o a incrementar su patrimonio.
+
+**Artículo Quinto:** La Asociación reconoce y adopta como principio general de
+funcionamiento la utilización preferente de medios electrónicos y digitales,
+los cuales tendrán plena validez jurídica, siempre que permitan acreditar de
+manera fehaciente la identidad, voluntad, fecha, contenido y trazabilidad de
+las actuaciones, sin perjuicio del cumplimiento de los quórum y mayorías
+establecidos en la ley y en estos estatutos.
+
+Para estos efectos, la Asociación podrá llevar y mantener registros en formato
+electrónico, incluyendo, a modo meramente enunciativo y no taxativo, el
+Registro de Miembros, libros de actas de Asambleas Generales y del Directorio,
+registros de votaciones, comunicaciones y archivos institucionales, los cuales
+tendrán el mismo valor y eficacia jurídica que sus equivalentes en soporte
+físico.
+
+Asimismo, los actos, acuerdos, comunicaciones, actas, certificaciones y demás
+documentos de la Asociación podrán ser suscritos mediante firma electrónica,
+ya sea firma electrónica avanzada, firma electrónica simple cuando la ley lo
+permita, o mediante certificados digitales válidamente emitidos, entendiéndose
+que tales firmas producen plenos efectos legales y probatorios, conforme a la
+normativa vigente.
+
+Las votaciones y elecciones de la Asociación, incluyendo aquellas relativas a
+Asambleas Generales, Directorio y Comisiones, podrán realizarse mediante
+sistemas de voto electrónico, siempre que dichos mecanismos permitan:
+
+* a) La identificación del votante;
+* b) La manifestación inequívoca de su voluntad;
+* c) La integridad e inalterabilidad del voto;
+* d) La trazabilidad y verificación del proceso; y
+* e) La conservación de los resultados para efectos de registro y control.
+
+El Directorio determinará los sistemas de votación electrónica a utilizar,
+debiendo éstos asegurar la transparencia, confidencialidad y validez del
+proceso.
+
+El voto electrónico podrá ser secreto o público, según la naturaleza de la
+materia sometida a votación y conforme a lo dispuesto en estos estatutos o en
+la convocatoria respectiva. En particular, las elecciones de autoridades
+deberán garantizar el carácter secreto del voto, salvo que exista acuerdo por
+mayoría simple de los socios asistentes con derecho a voto para efectuarla
+mediante votación pública.
+
+En caso de fallas técnicas, interrupciones de conectividad u otros
+inconvenientes que impidan el normal desarrollo del proceso de votación
+electrónica, el órgano que presida la respectiva sesión podrá:
+
+* Suspender temporalmente la votación;
+* Prorrogar el plazo para emitir el voto; o
+* Disponer la repetición total o parcial del proceso, dejando constancia de
+  ello en el acta respectiva.
+
+El Directorio será el órgano encargado de definir, implementar y administrar
+los sistemas de votación electrónica, debiendo velar por su seguridad,
+confidencialidad, transparencia y confiabilidad, sin perjuicio de las
+facultades de fiscalización que correspondan a la Asamblea General.
+
+Los acuerdos adoptados mediante votación electrónica se entenderán válidamente
+adoptados para todos los efectos legales y estatutarios, siempre que se
+cumplan los quórum y mayorías exigidos por la ley y por estos estatutos.
+
+**Artículo Sexto:** La duración de la Asociación será indefinida y el número
+de sus socios, será ilimitado.
+
+## Título II: De los miembros
+
+**Artículo Séptimo:** Podrá ser miembro de la Asociación toda persona sin
+limitación alguna de sexo, nacionalidad o condición.
+
+**Artículo Octavo:** Habrá dos clases de miembros: activos y honorarios.
+
+1. Miembro activo es la persona natural mayor de 18 años, que tiene la
+   plenitud de los derechos y obligaciones que se establecen en estos
+   estatutos.
+2. Miembro Honorarios es la persona natural o jurídica que, por su actuación
+   destacada al servicio de los intereses de la Asociación o de los objetivos
+   que ella persigue, haya obtenido esa distinción, en virtud de un acuerdo de
+   la Asamblea General, aceptada por el interesado. Él no tendrá obligación
+   alguna para con la Asociación y sólo tendrá derecho a voz en las Asambleas
+   Generales, a ser informado periódicamente de la marcha de la Institución y
+   a asistir a los actos públicos de ella.
+
+Las personas jurídicas harán uso de sus derechos, por intermedio de su
+representante legal, o apoderado.
+
+**Artículo Noveno:** La calidad de socio activo se adquiere:
+
+1. Por la suscripción del acta de constitución de la Asociación; o
+2. Por la presentación de una solicitud de ingreso por parte del interesado,
+   la cual podrá efectuarse por medios electrónicos, ya sea mediante
+   formulario digital habilitado por la Asociación o a través del correo
+   electrónico institucional que ésta determine.
+
+La solicitud de ingreso deberá contener una manifestación expresa del
+solicitante en orden a:
+
+* a) Conocer y aceptar íntegramente los fines de la Asociación; y
+* b) Comprometerse a cumplir fielmente los estatutos, reglamentos y los
+  acuerdos válidamente adoptados por la Asamblea General y el Directorio.
+
+La aprobación de las solicitudes de ingreso podrá ser efectuada
+indistintamente por:
+
+* a) El Secretario del Directorio;
+* b) Un Director especialmente designado para estos efectos; o
+* c) El Directorio, conforme a sus atribuciones generales.
+
+Recibida una solicitud que cumpla con los requisitos formales, ésta se
+entenderá aprobada automáticamente si dentro del plazo de 5 días corridos no
+se formula objeción fundada por parte de algún miembro del Directorio, lo que
+deberá constar por escrito o por medios electrónicos fehacientes.
+
+Sin perjuicio de lo anterior, el Directorio conservará en todo momento la
+facultad de revisar, ratificar o rechazar fundadamente una solicitud de
+ingreso, aun cuando ésta hubiere sido aprobada de manera automática o por
+delegación, debiendo dejar constancia de las razones del rechazo en el acta o
+registro respectivo.
+
+El auspicio o recomendación de socios no constituirá requisito obligatorio
+para el ingreso. No obstante, el solicitante podrá acompañar, de manera
+voluntaria, el respaldo de uno o más socios activos, el cual no será
+vinculante para la decisión.
+
+La aceptación, rechazo u observación de la solicitud, así como la fecha de
+ingreso, deberán quedar registradas en el Registro de Miembros, el que podrá
+llevarse en formato físico o digital, asegurando la trazabilidad del
+procedimiento.
+
+La calidad de miembro honorario se adquiere por acuerdo de la Asamblea
+General, adoptado por los dos tercios de los socios presentes o representados
+con derecho a voto, el que deberá ser aceptado expresamente por el interesado,
+pudiendo dicha aceptación manifestarse también por medios electrónicos.
+
+**Artículo Décimo:** Los socios activos tienen las siguientes obligaciones:
+
+* a) Asistir a las reuniones a que fueren convocados de acuerdo a sus
+  estatutos;
+* b) Servir con eficiencia y dedicación los cargos para los cuales sean
+  designados y las tareas que se le encomienden;
+* c) Cumplir fiel y oportunamente las obligaciones pecuniarias para con la
+  Asociación;
+* d) Cumplir las disposiciones de los estatutos y reglamentos de la
+  Asociación y acatar los acuerdos del Directorio y de las Asambleas
+  Generales.
+
+**Artículo Décimo Primero:** Los socios activos tienen los siguientes derechos
+y atribuciones:
+
+* a) Participar con derecho a voz y voto en las Asambleas Generales;
+* b) Elegir y ser elegidos para servir los cargos directivos de la
+  Asociación;
+* c) Pedir información acerca de las cuentas de la Asociación, así como de
+  sus actividades o programas;
+* d) Presentar cualquier proyecto o proposición al estudio del Directorio, el
+  que decidirá su rechazo o inclusión en la Tabla de una Asamblea General
+  Ordinaria. Si el proyecto fuera patrocinado por el 10% o más de los socios y
+  presentado con, a lo menos, 30 días de anticipación a la celebración de la
+  Asamblea General, deberá ser tratado en ésta, a menos que la materia sea de
+  aquellas estipuladas en el artículo décimo sexto de estos estatutos, en cuyo
+  caso deberá citarse para una Asamblea General Extraordinaria a celebrarse
+  dentro del plazo de 20 días contados desde la presentación hecha al
+  Directorio.
+
+**Artículo Décimo Segundo:** La calidad de socio activo se pierde por
+fallecimiento, por renuncia escrita y firmada digitalmente mediante firma
+electrónica, presentada al Directorio, o por expulsión decretada en
+conformidad al artículo décimo tercero letra d), de estos estatutos.
+
+Tratándose de miembros honorarios, se pierde la calidad de tal, por acuerdo de
+la Asamblea General, adoptado por motivos graves y fundados, por renuncia
+escrita y firmada digitalmente mediante firma electrónica avanzada, presentada
+al Directorio y por término de la personalidad jurídica en el caso de personas
+jurídicas.
+
+La renuncia a la calidad de socio activo producirá efectos desde su recepción
+por la Asociación, debiendo el secretario dejar constancia en el Registro de
+Miembros.
+
+**Artículo Décimo Tercero:** La Comisión de Ética (también podrá denominarse
+Tribunal de honor u otra denominación semejante) de que trata el Título VIII
+de estos estatutos, previa investigación de los hechos efectuada por un
+Instructor podrá sancionar a los socios con las medidas disciplinarias que se
+señalan más adelante. La investigación de los hechos se encargará a un
+Instructor, que será una persona integrante (socio) de la Asociación, no
+comprometido en el hecho que se investiga, quien será designado por el
+Directorio. La Comisión de Ética podrá aplicar las siguientes medidas
+disciplinarias:
+
+* a) Amonestación verbal.
+* b) Amonestación por escrito.
+* c) Suspensión:
+    1. Hasta por tres meses de todos los derechos en la Asociación, por
+       incumplimiento de las obligaciones prescritas en el artículo noveno.
+    2. Transitoriamente, por atraso superior a 90 días en el cumplimiento de
+       sus obligaciones pecuniarias para con la Asociación, suspensión que
+       cesará de inmediato al cumplirse la obligación morosa.
+    3. Tratándose de inasistencias a reuniones se aplicará la suspensión por
+       tres o más inasistencias injustificadas, dentro del año calendario.
+       Durante la suspensión el miembro afectado no podrá hacer uso de ninguno
+       de sus derechos, salvo que la Comisión de Ética haya determinado
+       derechos específicos respecto de los cuales queda suspendido.
+* d) Expulsión basada en las siguientes causales:
+    1. Incumplimiento de las obligaciones pecuniarias para con la Asociación
+       durante seis meses consecutivos, sea por cuotas ordinarias o
+       extraordinarias.
+    2. Causar grave daño de palabra, por escrito o con obras a los intereses
+       de la Asociación. El daño debe haber sido comprobado por medios
+       incuestionables.
+    3. Haber sufrido tres suspensiones en sus derechos, por alguna de las
+       causales establecidas en la letra c) de este artículo, en un período de
+       2 años contados desde la primera suspensión.
+
+Las medidas disciplinarias, entre ellas la expulsión, la resolverá la Comisión
+de Ética, previa investigación encargada al Instructor, ante quien el socio
+tendrá el derecho de ser oído, presentar sus descargos y defenderse de la
+acusación que se formule en su contra. La investigación se iniciará citando
+personalmente al socio. Una vez terminada la investigación, el Instructor
+elevará los antecedentes a la Comisión de Ética para que dicte fallo,
+proponiendo la aplicación de una medida disciplinaria prevista en el estatuto
+o la absolución. La Comisión de Ética deberá fallar dentro del plazo de
+treinta días, sin perjuicio de que pueda ampliarse este plazo, en el caso que
+deba solicitarse nuevas pruebas. La resolución de la Comisión de Ética deberá
+notificarse al socio mediante carta certificada dirigida al domicilio que el
+socio haya indicado al hacerse parte en la investigación, o al que tenga
+registrado en la Asociación, si no comparece. La notificación se entenderá
+practicada al quinto día hábil después de entregada la carta en la oficina de
+Correos. De la expulsión se podrá pedir reconsideración ante la misma Comisión
+de Ética, apelando en subsidio ante una Asamblea General Extraordinaria,
+dentro del plazo de treinta días hábiles, contados desde la respectiva
+notificación. La Asamblea General Extraordinaria deberá ser citada
+especialmente para este efecto, la cual resolverá en definitiva la aplicación
+de la medida disciplinaria. Si el socio no apela, la expulsión aplicada por la
+Comisión de Ética deberá ser ratificada también por la Asamblea General. Quien
+fuere excluido de la Asociación sólo podrá ser readmitido después de un año
+contando desde la separación, previa aceptación del Directorio, que deberá ser
+ratificada en la Asamblea General más próxima que se celebre con posterioridad
+a dicha aceptación del Directorio.
+
+**Artículo Décimo Cuarto:** El secretario, un Director designado, o quien
+determine el Directorio, será responsable de:
+
+* Recibir, registrar y tramitar las solicitudes de ingreso;
+* Verificar el cumplimiento de los requisitos formales;
+* Dejar constancia del ingreso o rechazo en el Registro de Miembros, el que
+  podrá llevarse en formato físico o digital.
+
+El Directorio deberá pronunciarse sobre las solicitudes de ingreso, en la
+primera sesión que celebre después de presentada éstas. En ningún caso podrán
+transcurrir más 30 días desde la fecha de la presentación, sin que el
+Directorio conozca de ellas y resuelva, transcurrido el plazo, la solicitud se
+entenderá aceptada. Las solicitudes de ingreso presentadas con 10 días de
+anticipación a la fecha de celebración de una Asamblea General en que deban
+realizarse elecciones deberán ser conocidas por el Directorio antes de dicha
+Asamblea.
+
+Las renuncias, para que sean válidas, deben constar por escrito y la firma
+debe ser ratificada ante el Secretario del Directorio, o venir autorizada por
+Notario Público, o firmadas digitalmente mediante certificado digital o firma
+electrónica avanzada. Cumplidos estos requisitos formales la renuncia tendrá
+pleno vigor, no siendo necesaria su aprobación por el Directorio o por la
+Asamblea. El socio que, por cualquier, causa dejare de pertenecer a la
+Asociación, deberá cumplir con sus obligaciones pecuniarias que hubiere
+contraído con ella, hasta la fecha en que se pierda la calidad de socio.
+
+## Título III: De las Asambleas Generales
+
+**Artículo Décimo Quinto:** La Asamblea General es el órgano colectivo
+principal de la Asociación e integra al conjunto de sus socios. Sus acuerdos
+obligan a los socios presentes y ausentes, siempre que tales acuerdos se
+hubieren tomado en la forma establecida por estos estatutos y no fueren
+contrarios a las Leyes y reglamentos.
+
+Habrá Asambleas Generales Ordinarias y Extraordinarias. La Asamblea se reunirá
+ordinariamente una vez al año, y extraordinariamente cuando lo exijan las
+necesidades de la Asociación. En el mes de abril de cada año se celebrará la
+Asamblea General Ordinaria, en la cual el Directorio presentará el Balance del
+ejercicio anterior, y se procederá a las elecciones determinadas por estos
+estatutos, cuando corresponda. El Directorio, con acuerdo de la Asamblea,
+podrá establecer que el acto eleccionario se celebre en otro día, hora y
+lugar, que no podrá exceder en 30 días a la fecha original, cuando rezones de
+conveniencia institucional así lo indiquen. En dicho caso, se cumplirá con lo
+dispuesto en el artículo décimo séptimo de estos estatutos.
+
+En la Asamblea General Ordinaria se fijará la cuota ordinaria de
+incorporación, conforme a lo señalado en el artículo cuadragésimo tercero de
+estos estatutos. En la Asamblea General Ordinaria podrá tratarse cualquier
+asunto relacionado con los intereses de la Asociación, a excepción de los que
+correspondan exclusivamente a las Asambleas Generales Extraordinarias.
+
+Si, por cualquier causa, no se celebrare Asamblea General Ordinaria en el
+tiempo estipulado, el Directorio deberá convocar a una nueva Asamblea dentro
+del plazo de 30 días y la Asamblea que se celebre tendrá, en todo caso, el
+carácter de Asamblea Ordinaria.
+
+Las Asambleas Generales, así como las sesiones de Directorio y reuniones de
+Comisiones podrán celebrarse total o parcialmente por medios telemáticos,
+siempre que se garantice:
+
+* a) Identidad de los participantes;
+* b) Comunicación simultánea o sucesiva;
+* c) Registro de asistencia;
+* d) Validez de las votaciones y acuerdos.
+
+Se entenderá que un socio o director se encuentra presente cuando participe
+efectivamente por el medio electrónico habilitado.
+
+Estas sesiones podrán ser gravadas, debiendo en este caso guarda un registro
+de la grabación.
+
+**Artículo Décimo Sexto:** Las Asambleas Generales Extraordinarias se
+celebrarán cada vez que el Directorio acuerde convocarlas, o cada vez que se
+lo soliciten al Presidente del Directorio, por escrito, a lo menos un tercio
+de los miembros activos, indicando el objeto de la reunión.
+
+En las Asambleas Generales Extraordinarias se fijará la cuota extraordinaria
+conforme lo señalado en el artículo cuadragésimo cuarto de estos estatutos. En
+las Asambleas Generales Extraordinarias únicamente podrán tratarse las
+materias indicadas en la convocatoria; cualquier acuerdo que se adopte sobre
+otras materias será nulo y de ningún valor.
+
+**Artículo Décimo Séptimo:** Corresponde exclusivamente a la Asamblea General
+Extraordinaria tratar de las siguientes materias:
+
+* a) De la reforma de los estatutos de la Asociación y la aprobación de sus
+  reglamentos;
+* b) De la disolución de la Asociación;
+* c) De la fusión con otra Asociación;
+* d) De las reclamaciones en contra de los directores, de los miembros de la
+  Comisión Revisora de Cuentas y de la Comisión de Ética, para hacer efectiva
+  la responsabilidad que les corresponda, por transgresión grave a la Ley, a
+  los estatutos o al reglamento, mediante la suspensión o la destitución, si
+  los cargos fueran comprobados; sin perjuicio de las acciones civiles y
+  criminales que la Asociación tenga derecho a entablarles;
+* e) De la asociación de la entidad con otras instituciones similares;
+* f) De la compra, venta, hipoteca, permuta, cesión y transferencia de bienes
+  raíces, de la constitución de servidumbres y prohibiciones de gravar y
+  enajenar y del arrendamiento de inmuebles por un plazo superior a tres años.
+
+Los acuerdos a que se refieren las letras a), b), c), e) y f) deberán
+reducirse a escritura pública que suscribirá el Presidente en representación
+de la Asociación, sin perjuicio de que en un caso determinado, la Asamblea
+General Extraordinaria pueda otorgar poder especial para este efecto, a otra u
+otras personas.
+
+**Artículo Décimo Octavo:** Las citaciones a Asambleas Generales Ordinarias y
+Extraordinarias se efectuarán mediante correo electrónico a la dirección
+registrada por el miembro, y mediante publicación en el sitio web oficial u
+otro canal digital institucional que determine el Directorio. La citación
+deberá indicar tipo de asamblea, fecha, hora, modalidad, tabla y medio de
+acceso si corresponde, y practicarse con al menos cinco días corridos de
+anticipación.
+
+Cuando la ley aplicable o estos estatutos lo exijan expresamente, o cuando el
+Directorio lo estime necesario para mayor publicidad, se publicará además un
+aviso por una vez en un diario de circulación nacional, pudiendo practicarse
+en un diario electrónico, dentro de los plazos estatutarios.
+
+La citación deberá despacharse por el Secretario, en conformidad a lo
+dispuesto en el artículo trigésimo cuarto, letra. En el evento que el
+Secretario no despachare las citaciones a Asambleas Generales, lo podrá hacer,
+en su defecto, la mayoría absoluta de los directores o el 10% de los socios
+activos.
+
+**Artículo Décimo Noveno:** Las Asambleas Generales Ordinarias y
+Extraordinarias se entenderán legalmente instaladas y constituidas si a ellas
+concurriere, presencial o telemáticamente, a lo menos, la mitad más uno de los
+socios activos. Si no se reuniere este quórum se dejará constancia del hecho
+en el acta y deberá disponerse una nueva citación para día diferente, dentro
+de los 5 días siguientes al de la primera citación, en cuyo caso la Asamblea
+se realizará con los socios que asistan.
+
+Los acuerdos en las Asambleas Generales se adoptarán por la mayoría absoluta
+de los socios asistentes, salvo en los casos en que la Ley o los estatutos
+hayan fijado una mayoría especial.
+
+**Artículo Vigésimo:** Cada socio activo tendrá derecho a un voto, pudiendo
+delegarlo en otro mediante un poder simple.
+
+Cada socio, además de hacer uso de su derecho a voto, sólo podrá representar a
+un socio activo. Los poderes serán calificados por el Secretario del
+Directorio, los cuales podrán presentarse hasta una media hora antes del
+inicio de la Asamblea.
+
+El derecho a voto podrá ejercerse por medios electrónicos, mediante sistemas
+que permitan verificar identidad, voluntad y resultado, los que deberán ser
+definidos por el Directorio y ratificados por la Asamblea.
+
+**Artículo Vigésimo Primero:** De las deliberaciones y acuerdos adoptados en
+las Asambleas Generales se dejará constancia en un libro especial de Actas o
+Registro que asegure la fidelidad de las mismas, el que será llevado por el
+Secretario. Estas Actas serán un extracto de lo ocurrido en la reunión y serán
+firmadas por el Presidente, por el Secretario o por quienes hagan sus veces, y
+además por tres socios activos asistentes, designados en la misma Asamblea
+para este efecto.
+
+En dichas Actas podrán los asistentes estampar las reclamaciones que estimen
+convenientes a sus derechos, por posibles vicios de procedimiento o relativos
+a la citación, constitución y funcionamiento de la Asamblea.
+
+Por otra parte, la Asociación deberá mantener permanentemente actualizados
+registros de sus asociados, directores y demás autoridades que prevean los
+estatutos.
+
+**Artículo Vigésimo Segundo:** Las Asambleas Generales serán presididas por el
+Presidente de la Asociación y actuará como Secretario el que lo sea del
+Directorio, o las personas que hagan sus veces. Si faltare el Presidente,
+presidirá la Asamblea un Director u otra persona que la propia Asamblea
+designe para ese efecto.
+
+## Título IV: Del Directorio
+
+**Artículo Vigésimo Tercero:** La institución será dirigida y administrada por
+un Directorio compuesto por cinco miembros, de entre los que deberá designarse
+un Presidente, Vicepresidente, un Secretario, un Tesorero y un Director. El
+Directorio 1 año en sus funciones pudiendo sus miembros ser reelegidos.
+
+Los Directores ejercerán su cargo gratuitamente, pero tendrán derecho a ser
+reembolsados de los gatos, autorizados por el directorio, que justificaren
+haber efectuado en el ejercicio de su función.
+
+Sin embargo, el directorio podrá fijar una retribución adecuada a aquellos
+directores que presten a la organización servicios distintos de sus funciones
+como directores. De toda remuneración o retribución que reciban los
+directores, o las personas naturales o jurídicas que les sean relacionadas por
+parentesco o convivencia, o por interés o propiedad, deberá darse cuenta
+detallada a la Asamblea.
+
+La regla anterior se aplicará respecto de todo asociado a quien la Asociación
+encomiende alguna función remunerada.
+
+**Artículo Vigésimo Cuarto:** Los cargos del Directorio serán elegidos
+directamente por la Asamblea General, votándose cada cargo en forma
+individual, pudiendo presentarse candidaturas específicas para cada uno, y
+saldrá electo el que obtenga la mayoría de los votos válidamente emitidos. En
+caso de empate se procederá a una nueva votación entre las 2 mayorías
+relativas, resultando electo aquel de los candidatos que obtenga la mayoría de
+los votos válidamente emitidos. En caso de un nuevo empate la designación
+recaerá en el Socio más antiguo y en caso de tener la misma antigüedad, por
+sorteo.
+
+Las elecciones podrán realizarse presencialmente o mediante votación
+electrónica, garantizando el carácter libre, secreto y verificable del voto.
+
+Los Directores durarán 1 año en sus funciones y podrán ser reelegidos
+indefinidamente, permaneciendo en funciones hasta la elección del nuevo
+Directorio, para efectos de continuidad administrativa ante terceros.
+
+Es incompatible el cargo de Director con el de miembro de la Comisión Revisora
+de Cuentas y de la Comisión de Ética.
+
+* No completándose el número necesario de Directores, de miembros de la
+  Comisión Revisora de Cuentas o de la Comisión de Ética, se procederá a
+  efectuar tantas elecciones como sea necesario. Existiendo empate entre dos o
+  más candidatos que ocupen el último lugar entre las más altas mayorías
+  respectivas, se repetirá la votación entre ellos y, si subsiste el empate,
+  se recurrirá para dirimirlo, en primer lugar, a la antigüedad de los
+  candidatos como socios de la Asociación y, si se tratare de socios con la
+  misma antigüedad, al sorteo.
+* Habrá una Comisión de Elecciones, integrada por tres socios que no sean
+  candidatos, quienes velaran por el proceso eleccionario, siendo estos
+  responsables civil y penalmente de las funciones inherentes al cargo.
+* Las elecciones deberán llevarse a cabo al menos 30 días antes de finalizar
+  el periodo, debiendo ser citados por el presidente del Directorio. En caso
+  de que el presidente del directorio no cite a votaciones para un nuevo
+  periodo, esto podrá realizarlo el Vicepresidente, el Secretario, o el
+  Tesorero, sin perjuicio de las responsabilidades civiles o penales que esto
+  pueda ocasionar. El no citar en el tiempo que este reglamento señale será
+  causal suficiente de expulsión.
+* El recuento de votos será público.
+* El Directorio elegido asumirá sus funciones, una vez una vez que se
+  complete el periodo del Directorio Saliente, sin perjuicio de las
+  rendiciones de cuentas y la entrega de documentos que deba realizarse con
+  posterioridad, para la cual, deberá en ese acto fijarse una fecha.
+
+**Artículo Vigésimo Quinto:** En caso de fallecimiento, ausencia, renuncia,
+destitución o imposibilidad de un Director para el desempeño de su cargo, el
+Directorio le nombrará un reemplazante interino, debiendo citarse a una
+Asamblea General a realizarse en un plazo máximo de 30 días para llevar a cabo
+la designación. El director electo durara en su cargo hasta completar el
+periodo que le faltaba a su antecesor. Si la vacancia se produjese faltando 6
+meses para completar el periodo, el Director Interino nombrado por el
+Directorio se mantendrá en su cargo sólo por el tiempo que falte para
+completar su período al Director reemplazado.
+
+Se entiende por ausencia o imposibilidad de un Director para el desempeño de
+su cargo, la inasistencia a sesiones por un período superior a seis meses
+consecutivos.
+
+**Artículo Vigésimo Sexto:** Podrá ser elegido miembro del Directorio,
+cualquier socio activo, con un año o más de pertenencia en la Institución,
+siempre que al momento de la elección no se encuentre suspendido en sus
+derechos, conforme a los dispuesto en el artículo décimo segundo letra c) de
+estos estatutos.
+
+No podrá ser directores las personas que hayan sido condenadas a pena
+aflictiva.
+
+El Directorio que durante el desempeño del cargo fuere condenado por crimen o
+simple delito, o incurriere en cualquier otro impedimento o causa de
+inhabilidad o incompatibilidad establecida por la ley o los estatutos, cesará
+en sus funciones, debiendo el Directorio nombrar a un reemplazante conforme a
+lo establecido en el Artículo Vigésimo Quinto.
+
+**Artículo Vigésimo Séptimo:** Serán deberes y atribuciones del Directorio:
+
+* a) Dirigir la Asociación y velar porque se cumplan sus estatutos y las
+  finalidades perseguidas por ella;
+* b) Administrar los bienes de la Asociación e invertir sus recursos;
+* c) Aprobar los proyectos y programas que se encuentren ajustados a los
+  objetivos de la Asociación;
+* d) Citar a Asamblea General, tanto ordinaria como extraordinaria, en la
+  forma y épocas que señalen estos estatutos;
+* e) Crear toda clase de ramas, sucursales, filiales, anexos, oficinas y
+  departamentos que se estime necesario para el mejor funcionamiento de la
+  Asociación;
+* f) Redactar los Reglamentos necesarios para la Asociación, las ramas y
+  organismos que se creen para el cumplimiento de sus fines y someter dichos
+  Reglamentos a la aprobación de la Asamblea General más próxima, pudiendo en
+  el intertanto aplicarlos en forma provisoria, como asimismo realizar todos
+  aquellos asuntos y negocios que estime necesario;
+* g) Cumplir los acuerdos de las Asambleas Generales;
+* h) Rendir cuenta en la Asamblea General Ordinaria anual, tanto de la marcha
+  de la Institución como de la inversión de sus fondos durante el periodo que
+  ejerza sus funciones, mediante memoria, balance e inventario, que en esa
+  ocasión se someterán a la aprobación de sus miembros;
+* i) Calificar la ausencia e imposibilidad de sus miembros para desempeñar el
+  cargo, a que se refiere el artículo vigésimo cuarto;
+* j) Resolver las dudas y controversias que surjan con motivo de la
+  aplicación de sus estatutos y reglamentos; y
+* k) Las demás atribuciones que señalen estos estatutos y la Legislación
+  vigente.
+
+**Artículo Vigésimo Octavo:** Como administrador de los bienes de la
+Asociación, el Directorio estará facultado para: Comprar, adquirir, vender,
+permutar, dar y tomar en arrendamiento y administración, ceder y transferir
+toda clase de bienes muebles y valores mobiliarios; dar y tomar en
+arrendamiento bienes inmuebles por un período no superior a tres años; dar en
+garantía y establecer prohibiciones sobre bienes muebles, otorgar
+cancelaciones, recibos y finiquitos; celebrar contratos de trabajo, fijar sus
+condiciones y poner término a ellos; celebrar contratos de mutuo y cuentas
+corrientes, abrir y cerrar cuentas corrientes, de depósitos, de ahorro y de
+crédito, girar y sobregirar en ellas; retirar talonarios y aprobar saldos;
+girar, aceptar, tomar, avalar, endosar, descontar, cobrar, cancelar, prorrogar
+y protestar letras de cambio, pagarés, cheques y demás documentos negociables
+o efectos de comercio; ejecutar todo tipo de operaciones bancarias o
+mercantiles; cobrar y percibir cuanto corresponda a la Asociación; contratar,
+alzar y posponer prendas, constituir, modificar, prorrogar, disolver y
+liquidar sociedades y comunidades; asistir a juntas con derecho a voz y voto;
+conferir mandatos especiales, revocarlos y transigir; aceptar toda clase de
+herencias, legados y donaciones; contratar seguros, pagar las primas, aprobar
+liquidaciones de los siniestros y percibir el valor de las pólizas, firmar,
+endosar y cancelar pólizas; importar y exportar; delegar en el Presidente, en
+uno o más Directores, o en uno más socios, o en terceros, sólo las
+atribuciones necesarias para ejecutar las medidas económicas que se acuerden y
+las que requiera la organización administrativa interna de la Institución;
+estipular en cada contrato que celebre los precios, plazos y condiciones que
+juzgue convenientes; anular, rescindir, resolver, revocar y terminar dichos
+contratos; poner término a los contratos vigentes por resolución, desahucio o
+cualquiera otra forma; operar en el mercado de valores; comprar y vender
+divisas sin restricción; contratar créditos y ejecutar todos aquellos actos
+que tiendan a la buena administración de la Asociación.
+
+Sólo por acuerdo de una Asamblea General Extraordinaria se podrá comprar,
+vender, hipotecar, permutar, ceder y transferir bienes raíces, constituir
+servidumbres y prohibiciones de gravar y enajenar y arrendar bienes inmuebles
+por un plazo superior a tres años.
+
+En el ejercicio de sus funciones, los directores responderán solidariamente
+hasta de la culpa leve por los perjuicios que causaren a la Asociación.
+
+**Artículo Vigésimo Noveno:** Acordado por el Directorio o la Asamblea General
+cualquier acto relacionado con las facultades indicadas en el artículo
+precedente, lo llevará a cabo el Presidente o quien lo subrogue en el cargo.
+Lo anterior se entiende sin perjuicio de que, en un caso determinado, se
+acuerde que el Presidente actuará conjuntamente con otro Director, o con el
+Secretario Ejecutivo, o bien se le otorgue poder especial a un tercero para la
+ejecución de un acuerdo. El Presidente o la o las personas que se designen
+deberán ceñirse fielmente a los términos del acuerdo de la Asamblea o del
+Directorio, en su caso y serán solidariamente responsables ante la Asociación
+en caso de contravenirlo.
+
+Sin embargo, no será necesario a los terceros que contraten con la Asociación
+conocer los términos del respectivo acuerdo, el que no les será oponible.
+
+**Artículo Trigésimo:** El Directorio deberá sesionar con la mayoría absoluta
+de sus miembros, y sus acuerdos se adoptarán por la mayoría absoluta de los
+Directores asistentes, salvo en los casos que estos mismos estatutos señalen
+un quórum distinto. En caso de empate decidirá el voto del que preside. El
+Directorio sesionará, sea presencialmente, telemáticamente o en forma mixta,
+al menos una vez al mes, en la fecha que acuerden sus integrantes.
+
+De las deliberaciones y acuerdos del Directorio se dejará constancia en un
+libro especial de actas, firmado por todos los directores que hubieren
+concurrido a la sesión.
+
+El Director que quisiere salvar su responsabilidad por algún acto o acuerdo,
+deberá exigir que se deje constancia de su oposición el en acta, debido darse
+cuenta de ello en la próxima Asamblea.
+
+El Directorio podrá sesionar extraordinariamente y para tal efecto el
+presidente deberá citar a sus miembros. En estas sesiones sólo podrán tratarse
+las materias objeto de la citación, rigiendo las mismas formalidades de
+constitución y funcionamiento establecidas para las sesiones ordinarias en
+este artículo.
+
+El Presidente estará obligado a practicar la citación por escrito mediante
+correo electrónico, si así lo requieren dos o más directores.
+
+## Título V: Del Presidente y del Vicepresidente
+
+**Artículo Trigésimo Primero:** Corresponde especialmente al Presidente de la
+Asociación:
+
+* a) Representarla Judicial y extrajudicialmente;
+* b) Presidir las reuniones del Directorio y las Asambleas Generales;
+* c) Ejecutar los acuerdos del Directorio, sin perjuicio de las funciones que
+  los Estatutos encomienden al Vicepresidente, Secretario, Tesorero y a otros
+  miembros que le Directorio designe;
+* d) Organizar los trabajos del Directorio y proponer el plan general de
+  actividades de la institución;
+* e) Nombrar las Comisiones de Trabajo que estime convenientes;
+* f) Firmar la documentación propia de su cargo y aquella en que deba
+  representar a la Asociación. Firmar conjuntamente con el Tesorero o con el
+  Director que haya designado el Directorio, los cheques, giros de dinero,
+  letras de cambio, balances y, en general, todos los documentos relacionados
+  con el movimiento de fondos de la Asociación;
+* g) Dar cuenta anualmente en la Asamblea General Ordinaria, en nombre del
+  Directorio, de la marcha de la Institución y del estado financiero de la
+  misma;
+* h) Resolver cualquier asunto urgente que se presente y solicitar en la
+  sesión de Directorio más próxima su ratificación;
+* i) Velar por el cumplimiento de los estatutos, reglamentos y acuerdos de la
+  Asociación;
+* j) Las demás atribuciones que determinen estos estatutos y los reglamentos.
+
+Los actos del representante de la Asociación son actos de ésta, en cuanto no
+excedan de los límites del ministerio que se le ha confiado. En todo lo que
+excedan estos límites, sólo obligan personalmente al representante.
+
+**Artículo Trigésimo Segundo:** El Vicepresidente debe colaborar
+permanentemente con el Presidente en todas las materias que a éste le son
+propias, correspondiéndole el control de la constitución y funcionamiento de
+las comisiones de trabajo. En caso de enfermedad, permiso, ausencia o
+imposibilidad transitoria, el Presidente será subrogado por el Vicepresidente,
+el que tendrá en tal caso todas las atribuciones que corresponden a aquel. En
+caso de fallecimiento, renuncia o imposibilidad definitiva del Presidente, el
+Vicepresidente ejercerá el cargo hasta la designación de un nuevo presidente
+conforme al artículo vigésimo quinto precedente.
+
+## Título VI: Del Secretario, del Tesorero y del Director Ejecutivo
+
+**Artículo Trigésimo Tercero:** Los deberes del Secretario serán los
+siguientes:
+
+* a) Llevar el Libro de Actas del Directorio, el de Asamblea de Socios y el
+  Libro de Registro de Miembros de la Asociación;
+* b) Despachar las citaciones a las Asambleas ordinarias y extraordinarias y
+  publicar los avisos de citación de las mismas;
+* c) Formar la tabla de sesiones del Directorio y de las Asambleas Generales,
+  de acuerdo con el Presidente;
+* d) Redactar y despachar con su firma y la del Presidente la correspondencia
+  y documentación de la Asociación, con excepción de aquella que corresponda
+  exclusivamente al Presidente y recibir y despachar la correspondencia en
+  general;
+* e) Contestar personalmente la correspondencia de mero trámite;
+* f) Vigilar y coordinar que, tanto los directores como los miembros, cumplan
+  con las funciones y comisiones que les corresponden conforme a los estatutos
+  y reglamentos o les sean encomendadas para el mejor funcionamiento de la
+  Asociación;
+* g) Firmar las actas en calidad de Ministro de Fe de la Institución y
+  otorgar copia de ellas debidamente autorizadas con su firma, cuando se lo
+  solicite algún miembro de la Asociación;
+* h) Calificar los poderes antes de las elecciones;
+* i) En general, cumplir todas las tareas que le encomienden.
+
+En caso de ausencia o imposibilidad, el Secretario será subrogado por el
+director que designe el Directorio.
+
+**Artículo Trigésimo Cuarto:** Las funciones del Tesorero serán las
+siguientes:
+
+* a) Cobrar las cuotas ordinarias, extraordinarias y de inAsociación
+  otorgando recibos por las cantidades correspondientes;
+* b) Depositar los fondos de la Asociación en las cuentas corrientes o de
+  ahorro que ésta abra o mantenga y firmar conjuntamente con el Presidente, o
+  con quien designe el Directorio los cheques o retiros de dinero que se giren
+  contra dichas cuentas;
+* c) Llevar la Contabilidad de la Institución;
+* d) Preparar el Balance que el Directorio deberá proponer anualmente a la
+  Asamblea General;
+* e) Mantener al día el inventario de todos los bienes de la Institución;
+* f) En general, cumplir con todas las tareas que le encomienden.
+
+El Tesorero, en caso de ausencia, o imposibilidad, será subrogado por el
+Director que designe el Directorio. En caso de renuncia o fallecimiento, será
+el Directorio quien designará el reemplazante, el que durará en su cargo sólo
+el tiempo que faltare al reemplazado.
+
+**Artículo Trigésimo Quinto:** Podrá existir un funcionario con el título de
+Director Ejecutivo, que será designado por el Directorio y durará en funciones
+mientras cuente con la confianza de éste. Al Director Ejecutivo le
+corresponderá hacer cumplir los acuerdos del Directorio sólo en los casos en
+que se le haya otorgado un poder especial, para un asunto determinado,
+pudiendo concurrir a las sesiones de Directorio sólo con derecho a voz, sin
+derecho a voto. El Director Ejecutivo no formará parte del Directorio, será
+una persona ajena a la institución y no tendrá la calidad de miembro de la
+misma.
+
+Al Director Ejecutivo le corresponderá realizar las siguientes funciones, sin
+perjuicio de las que el Directorio le asigne:
+
+* a) Estructurar la organización administrativa de la Asociación, de acuerdo
+  a las instrucciones que le imparta el Directorio, velando por su correcto
+  funcionamiento;
+* b) Llevar conjuntamente con el Tesorero la contabilidad de la Institución,
+  elaborando el balance y presupuesto anual para presentarlo al Directorio;
+* c) Celebrar los actos y contratos aprobados por el Directorio conforme a
+  las condiciones y modalidades que éste haya fijado, respecto de los cuales
+  se le haya conferido poder especial para ello;
+* d) Ejercer las facultades que el Directorio le hubiere especialmente
+  delegado. El directorio podrá delegar en el Director Ejecutivo, sólo las
+  atribuciones necesarias para ejecutar las medidas económicas que se acuerden
+  y las que requiera la organización administrativa interna de la Institución;
+* e) Proponer al Directorio las medidas, normas o procedimientos que tiendan
+  al mejoramiento de los servicios que preste la Institución, como también a
+  su organización interna.
+
+## Título VII: De la Comisión Revisora de Cuentas
+
+**Artículo Trigésimo Sexto:** En la Asamblea General Ordinaria Anual que
+corresponda, los miembros activos elegirán una Comisión Revisora de Cuentas,
+compuesta por tres de ellos, quienes durarán 1 año en sus funciones y cuyas
+obligaciones y atribuciones serán las siguientes:
+
+* a) Revisar trimestralmente y cuando la situación lo amerite, los libros de
+  contabilidad y los comprobantes de ingresos y egresos que el Tesorero y el
+  Director Ejecutivo deben exhibirle, como, asimismo, inspeccionar las cuentas
+  bancarias y de ahorro;
+* b) Velar porque los miembros se mantengan al día en el pago de sus cuotas y
+  representar al Tesorero cuando alguno se encuentre atrasado, a fin de que
+  éste investigue la causa y procure se ponga al día en sus pagos;
+* c) Informar en Asamblea Ordinaria o Extraordinaria sobre la marcha de la
+  Tesorería y el estado de las finanzas y dar cuenta de cualquier
+  irregularidad que notare;
+* d) Elevar a la Asamblea Ordinaria Anual, un informe escrito sobre las
+  finanzas de la Institución, sobre la forma que se ha llevado la Tesorería
+  durante el año y sobre el balance del ejercicio anual que confeccione el
+  Tesorero, recomendando a la Asamblea la aprobación o rechazo total o parcial
+  del mismo; y
+* e) Comprobar la exactitud del inventario.
+
+**Artículo Trigésimo Séptimo:** La Comisión Revisora de Cuentas será presidida
+por el miembro que obtenga el mayor número de sufragios en la respectiva
+elección y no podrá intervenir en los actos administrativos del Directorio. En
+caso de vacancia en el cargo del Presidente será reemplazado con todas sus
+atribuciones por el miembro que obtuvo la votación inmediatamente inferior a
+éste. Si se produjera la vacancia simultánea de dos o más cargos de la
+Comisión Revisora de Cuentas, se llamará a nuevas elecciones para ocupar los
+puestos vacantes; si la vacancia fuera sólo de un miembro continuará con los
+que se encuentren en funciones con todas las atribuciones de la Comisión. La
+Comisión sesionará con la mayoría absoluta de sus miembros y los acuerdos
+serán adoptados por la mayoría absoluta de los asistentes. En caso de empate,
+decidirá el voto del que preside.
+
+## Título VIII: De la Comisión de Ética
+
+**Artículo Trigésimo Octavo:** Habrá una Comisión de Ética, compuesta de tres
+miembros, elegidos cada 1 año en la Asamblea General Ordinaria Anual, en la
+forma y con los requisitos establecidos en el artículo vigésimo tercero.
+
+Los miembros de dicha Comisión durarán 1 año en sus funciones y podrán ser
+reelegidos indefinidamente.
+
+**Artículo Trigésimo Noveno:** La Comisión de Ética se constituirá dentro de
+los 30 días siguientes a su elección, procediendo a designar, de entre sus
+miembros, un Presidente y un Secretario. Deberá funcionar con la mayoría
+absoluta de sus miembros y sus acuerdos se adoptarán por la mayoría absoluta
+de los asistentes. En caso de empate, decidirá el voto del que preside. Todos
+los acuerdos de la Comisión deberán constar por escrito y los suscribirán
+todos los miembros asistentes a la respectiva reunión.
+
+**Artículo Cuadragésimo:** En caso ausencia, fallecimiento, renuncia o
+imposibilidad de alguno de los miembros de la Comisión de Ética para el
+desempeño de su cargo, el Directorio le nombrará un reemplazante que durará en
+sus funciones sólo el tiempo que faltare para completar su período al miembro
+de la Comisión reemplazado, el cual deberá tener la calidad de socio activo de
+la Asociación.
+
+Se considerará que existe ausencia o imposibilidad si el miembro de la
+Comisión no asiste por un período de tres meses.
+
+**Artículo Cuadragésimo Primero:** La Comisión de Ética, en el cumplimiento de
+sus funciones aplicará medidas disciplinarias, en primera instancia, previa
+investigación de los hechos efectuada por el Instructor, conforme al
+procedimiento que señala el artículo décimo segundo.
+
+## Título IX: Del Patrimonio
+
+**Artículo Cuadragésimo Segundo:** El patrimonio de la Asociación estará
+formado por los bienes que forman su patrimonio inicial, lo que corresponde a
+la suma de $1.000.000.-
+
+Además, formarán también el patrimonio las cuotas de incorporación, ordinarias
+y extraordinarias, determinadas con arreglo a los estatutos; por las
+donaciones entre vivos o asignaciones por causa de muerte que se le hicieren;
+por el producto de sus bienes o servicios remunerados que preste; por la venta
+de sus activos y por las erogaciones y subvenciones que obtenga de personas
+naturales o jurídicas, de las Municipalidades o del Estado y demás bienes que
+adquiera a cualquier título.
+
+Las rentas, utilidades, beneficios o excedentes de la Asociación no podrán por
+motivo alguno distribuirse a sus afiliados ni aún en caso de disolución,
+debiéndose emplear en el cumplimiento de sus fines estatutarios.
+
+**Artículo Cuadragésimo Tercero:** La cuota ordinaria mensual será determinada
+por la Asamblea General Ordinaria anual, a propuesta del Directorio, y no
+podrá ser inferior a $1.000.- (mil pesos chilenos). Asimismo, la cuota de
+incorporación será determinada por la Asamblea General Ordinaria del año
+respectivo, a propuesta del Directorio, y no podrá ser inferior a $1.000.-
+(mil pesos).
+
+El Directorio estará autorizado para establecer que el pago de las cuotas
+ordinarias se haga mensual, trimestral o semestralmente.
+
+**Artículo Cuadragésimo Cuarto:** Las cuotas extraordinarias serán
+determinadas por una Asamblea General Extraordinaria, a propuesta del
+Directorio. Se procederá a fijar y exigir una cuota de esta naturaleza, cada
+vez que lo requieran las necesidades de la Asociación. No podrá fijarse más de
+una cuota extraordinaria por mes. Los fondos recaudados por concepto de cuotas
+extraordinarias no podrán ser destinados a otro fin que al objeto para el cual
+fueron recaudados, a menos que una Asamblea General especialmente convocada al
+efecto, resuelva darle otro destino.
+
+## Título X: De la Modificación de Estatutos, de la Fusión y de la Disolución de la Asociación
+
+**Artículo Cuadragésimo Quinto:** La Asociación podrá modificar sus estatutos,
+sólo por acuerdo de una Asamblea General Extraordinaria adoptado por los dos
+tercios de los socios presentes.
+
+**Artículo Cuadragésimo Sexto:** La Asociación podrá fusionarse o disolverse
+voluntariamente por acuerdo de una Asamblea General Extraordinaria adoptada
+por los dos tercios de los miembros presentes.
+
+Acordada la disolución voluntaria o decretada la disolución forzada de la
+Asociación, sus bienes pasarán a la Institución sin fin de lucro, con
+personalidad jurídica vigente denominada Enseña Chile.

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -38,6 +38,7 @@ MENUELEMENTS = {
         "children": None,
     },
     "coordinación": {"title": "Coordinación", "url": "pages/coordinacion.html"},
+    "asociación": {"title": "Asociación", "url": "pages/asociacion.html", "children": None},
     "grupos": {"title": "Grupos", "url": "pages/grupos.html"},
     "eventos": {
         "title": "Eventos",


### PR DESCRIPTION
Closes #105

Agrega la página de la **Asociación** con la información entregada por la directiva (vía @acaneo en Discord):

* Directiva actual (presidente, vicepresidente, secretario, tesorero, director)
* Criterios de aceptación de nuevos socios
* Nota de que la cuota de incorporación y anual están por definir
* Datos de facturación (razón social, RUT, giro, dirección)

Agrega además la página de **Estatutos** en una página separada por su extensión (enlazada desde la página de la asociación), con el texto de los estatutos reformados aprobados en la Asamblea General Extraordinaria del 30 de mayo de 2026.

Ambas páginas quedan enlazadas y se agrega la entrada "Asociación" al menú de navegación.

**Notas para revisión:**

* Del documento de reforma de estatutos se publica solo el texto de los estatutos (Títulos I a X). Se excluyen el acta de la asamblea, los artículos transitorios y las firmas, ya que contienen datos personales (RUT y correos personales) que no deberían publicarse en el sitio.
* El texto de los estatutos se transcribe fiel al documento original, incluyendo algunas erratas del documento fuente (p. ej. "gatos" por "gastos" en el Artículo Vigésimo Tercero, "inAsociación" por "incorporación" en el Artículo Trigésimo Cuarto).
* El artículo transitorio del documento indica como Director a Antonio Rodríguez Mejías, mientras que la directiva informada por Discord indica a Alexis Alva Núñez; se usó esta última por ser más reciente. Por confirmar con @acaneo.