### PR TITLE
fix: declarar explícitamente el plugin pelican-image-process

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-pelican[markdown,images]
+pelican[markdown]
+pelican-image-process
 typogrify
 pillow


### PR DESCRIPTION
Reemplaza `pelican[markdown,images]` por `pelican[markdown]` + una dependencia explícita de `pelican-image-process` en `requirements.txt`.

## Por qué

El extra `images` ya no existe en Pelican 4.12. Desde Pelican 4.5 los plugins incluidos se separaron en paquetes independientes de PyPI bajo el namespace `pelican.plugins.*`, por lo que `pelican[images]` no instalaba nada (`uv` muestra `does not have an extra named 'images'` y continúa). Como consecuencia, el plugin `image_process` fallaba al importarse en una instalación nueva:

```
ERROR  Cannot load plugin `pelican.plugins.image_process`
       Cannot import plugin `pelican.plugins.image_process`
```

Declarar `pelican-image-process` directamente (se importa como `pelican.plugins.image_process`, coincidiendo con `pelicanconf.py`) soluciona las instalaciones desde cero.